### PR TITLE
Update motd copyright year

### DIFF
--- a/etc/update-motd.d/30_dist-base-files
+++ b/etc/update-motd.d/30_dist-base-files
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Copyright (C) 2012 - 2021 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## Copyright (C) 2012 - 2022 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
 ## See the file COPYING for copying conditions.
 
 ## Feel free to delete this file.
@@ -37,7 +37,7 @@ fi
 echo "Welcome to $name_machine ™!"
 echo "$project_website"
 echo "
-$name_regular_case Copyright (C) 2012 - 2021 ENCRYPTED SUPPORT LP
+$name_regular_case Copyright (C) 2012 - 2022 ENCRYPTED SUPPORT LP
 $name_regular_case is Freedom Software, and you are welcome to redistribute it under
 certain conditions; type \"${name_lower_case}-license\" <enter> for details.
 $name_regular_case is a compilation of software packages, each under its own copyright and


### PR DESCRIPTION
It's still outdated in various other files (both website and packages), but with this fix users will be greeted on the terminal with the correct copyright info.